### PR TITLE
Prototype: bugfix for telegraf config file + broker logs

### DIFF
--- a/prototype/README.md
+++ b/prototype/README.md
@@ -82,11 +82,11 @@ __Mosquitto__:
 
 ### Component Logs
 
-- For `mosquitto`:
+- For `mosquitto` Persistent Logs:
 
         cat mosquitto/log/mosquitto.log
 
-- For `telegraf`, `influxdb`, `grafana`:
+- For `telegraf`, `influxdb`, `grafana`, `mosquitto` stdout Logs:
 
     a. from root directory:
 
@@ -95,6 +95,8 @@ __Mosquitto__:
         docker-compose -f prototype/docker-compose.prototype.yml logs -f influxdb
         # OR
         docker-compose -f prototype/docker-compose.prototype.yml logs -f grafana
+        # OR
+        docker-compose -f prototype/docker-compose.prototype.yml logs -f mosquitto
 
     b. from `prototype` (this) directory:
 
@@ -103,6 +105,8 @@ __Mosquitto__:
         docker-compose -f docker-compose.prototype.yml logs -f influxdb
         # OR
         docker-compose -f docker-compose.prototype.yml logs -f grafana
+        # OR
+        docker-compose -f docker-compose.prototype.yml logs -f mosquitto
 
 ---
 

--- a/prototype/mosquitto/config/mosquitto.conf
+++ b/prototype/mosquitto/config/mosquitto.conf
@@ -7,6 +7,7 @@ persistence_location /mosquitto/data/
 
 # Logging
 log_dest file /mosquitto/log/mosquitto.log
+log_dest stdout
 log_timestamp true
 log_type all
 

--- a/prototype/telegraf/telegraf.conf
+++ b/prototype/telegraf/telegraf.conf
@@ -81,7 +81,7 @@
     connection_timeout = "30s"
 
     username = "${TG_MOSQUITTO_USERNAME}"
-    password = "${TG_MOSQUITTO_USERNAME}"
+    password = "${TG_MOSQUITTO_PASSWORD}"
 
     # Incoming MQTT Payload from Sensor nodes is in InfluxDB Line Protocol strings
     data_format = "influx"


### PR DESCRIPTION
- closes #8 
- relates to #7 where the `telegraf.conf` used the username for mosquitto broker also as a password
- Add `stdout` to `mosquitto.conf` in order to display logs via `docker-compose logs -f` command